### PR TITLE
Random RNG fix

### DIFF
--- a/data/scripts/RyuDebugMenu.inc
+++ b/data/scripts/RyuDebugMenu.inc
@@ -375,14 +375,8 @@ RyuDebug_ViewTempVars::
 RDB_TempVarsViewMsg:
 	.string "{STR_VAR_1}$"
 
-RyuDebug_Utility11::
-	clearflag FLAG_RYU_PROF_SPECIAL_FINISHED
-	release
-	end
-
 RyuDebug_Utility1::
-	callnative Hat_TestSprintf
-	msgbox gStringVar1, MSGBOX_DEFAULT
+	clearflag FLAG_RYU_PROF_SPECIAL_FINISHED
 	release
 	end
 

--- a/src/ach_atlas.c
+++ b/src/ach_atlas.c
@@ -26,7 +26,6 @@
 #include "overworld_notif.h"
 #include "constants/items.h"
 #include "item.h"
-//#include "printf.h"
 
 static const u8 sAPMenuBackgroundTileset[] = INCBIN_U8("graphics/achievement_atlas/apscreen.8bpp");
 static const u16 sAPMenuBackgroundTilemap[] = INCBIN_U16("graphics/achievement_atlas/apscreen.bin");
@@ -1544,13 +1543,6 @@ static void AtlasCursorSpriteCB(struct Sprite *sprite)
             break;
     }
     sprite->data[0] = ACTION_NONE;
-}
-
-void Hat_TestSprintf(void)
-{
-    u8* buf = gStringVar1;
-    StringCopy(buf, (u8[])_("test %d test"));
-    //hat_printf(buf, 5);
 }
 
 void Ryu_GiveOrTakeAllAchievments(void)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Standard random implementation uses +12345 while current impl uses +24691

## Description
<!--- Describe your changes in detail -->
UNIT test results confirming the change at https://replit.com/@NecroBuddy/ShimmeringSandybrownOolanguage#main.c

## **Discord contact info**
<!--- formatted as name#numbers, e.g. PikalaxALT#5823 -->
<!--- Contributors must join https://discord.gg/d5dubZ3 -->